### PR TITLE
Add feature to show a message/image when the connections get's stable again 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,6 @@ if(ENABLE_QT)
   )
 endif()
 
-target_sources(${CMAKE_PROJECT_NAME} PRIVATE
-  src/plugin-main.cpp
-  src/online-status.cpp
-  src/online_status_properties.cpp
-)
+target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-main.cpp src/online-status.cpp src/online_status_properties.cpp)
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 target_sources(${CMAKE_PROJECT_NAME} PRIVATE
   src/plugin-main.cpp
   src/online-status.cpp
+  src/online_status_properties.cpp
 )
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCO
 
 project(${_name} VERSION ${_version})
 
-option(ENABLE_FRONTEND_API "Use obs-frontend-api for UI functionality" OFF)
+# Plugin requires the OBS Frontend API (used for streaming output/frame stats)
+# Make it unconditional to avoid missing include paths on platforms (macOS)
 option(ENABLE_QT "Use Qt functionality" OFF)
 
 include(compilerconfig)
@@ -21,10 +22,9 @@ set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_EXTENSIONS OFF)
 find_package(libobs REQUIRED)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OBS::libobs)
 
-if(ENABLE_FRONTEND_API)
-  find_package(obs-frontend-api REQUIRED)
-  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OBS::obs-frontend-api)
-endif()
+# Always require obs-frontend-api (we call obs_frontend_get_streaming_output etc.)
+find_package(obs-frontend-api REQUIRED)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OBS::obs-frontend-api)
 
 if(ENABLE_QT)
   find_package(Qt6 COMPONENTS Widgets Core)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ Use in OBS
    - “Hide after seconds without drops” — how quickly it disappears once stable.
 6. Leave “Visible” on for normal behavior. The overlay will appear only during drops.
 
+### Sections Explained
+
+Dropping:
+- Active only while the plugin detects a recent burst of dropped frames above your threshold.
+- You pick Text or Image, the drop percentage that triggers it, optional blink, and how long to wait with no further drops before hiding.
+
+Stable:
+- Optional “recovery” message that appears after the dropping overlay disappears (i.e., when things stabilized).
+- Independent mode (Text/Image), duration timer, and its own blink controls.
+
+Advanced:
+- Manual test tools so you can simulate a drop spike or show/hide the stable message without needing real network problems.
+- Also contains the manual “Visible” toggle useful for debugging source placement.
+
 Notes
 
 - On Windows the plugin prefers “Text (GDI+)” for text rendering, and falls back to “Text (FreeType 2)” if needed.

--- a/src/online-status.cpp
+++ b/src/online-status.cpp
@@ -13,36 +13,36 @@
 // ------------------------ Readability helpers ------------------------
 static inline bool dropping_blink_ok(const OnlineStatus *s)
 {
-    return !s->drop_blink_enabled || s->drop_blink_on;
+	return !s->drop_blink_enabled || s->drop_blink_on;
 }
 
 static inline bool stable_blink_ok(const OnlineStatus *s)
 {
-    return !s->stable_blink_enabled || s->stable_blink_on;
+	return !s->stable_blink_enabled || s->stable_blink_on;
 }
 
 static inline bool should_show_dropping(const OnlineStatus *s)
 {
-    return (s->auto_visible || s->visible) && dropping_blink_ok(s);
+	return (s->auto_visible || s->visible) && dropping_blink_ok(s);
 }
 
 static inline bool should_show_stable(const OnlineStatus *s)
 {
-    return s->stable_visible && s->stable_enabled && stable_blink_ok(s);
+	return s->stable_visible && s->stable_enabled && stable_blink_ok(s);
 }
 
 static inline void sync_child_enabled(OnlineStatus *s)
 {
-    const bool show_drop = should_show_dropping(s);
-    const bool show_stable = should_show_stable(s);
-    if (s->status_text.get())
-        obs_source_set_enabled(s->status_text.get(), show_drop && s->content_mode == 0);
-    if (s->status_image.get())
-        obs_source_set_enabled(s->status_image.get(), show_drop && s->content_mode == 1);
-    if (s->status_text_stable.get())
-        obs_source_set_enabled(s->status_text_stable.get(), show_stable && s->stable_mode == 0);
-    if (s->status_image_stable.get())
-        obs_source_set_enabled(s->status_image_stable.get(), show_stable && s->stable_mode == 1);
+	const bool show_drop = should_show_dropping(s);
+	const bool show_stable = should_show_stable(s);
+	if (s->status_text.get())
+		obs_source_set_enabled(s->status_text.get(), show_drop && s->content_mode == 0);
+	if (s->status_image.get())
+		obs_source_set_enabled(s->status_image.get(), show_drop && s->content_mode == 1);
+	if (s->status_text_stable.get())
+		obs_source_set_enabled(s->status_text_stable.get(), show_stable && s->stable_mode == 0);
+	if (s->status_image_stable.get())
+		obs_source_set_enabled(s->status_image_stable.get(), show_stable && s->stable_mode == 1);
 }
 
 // release_source helper no longer needed with smart pointers
@@ -50,58 +50,58 @@ static inline void sync_child_enabled(OnlineStatus *s)
 // ------------------------ Child creation helpers ------------------------
 static obs_source_t *create_text_child_raw(const char *name, const char *text_value)
 {
-    // Candidate order depends on platform (prefer GDI+ on Windows, FT2 elsewhere)
+	// Candidate order depends on platform (prefer GDI+ on Windows, FT2 elsewhere)
 #ifdef _WIN32
-    const char *candidates[] = {"text_gdiplus", "text_ft2_source_v2"};
+	const char *candidates[] = {"text_gdiplus", "text_ft2_source_v2"};
 #else
-    const char *candidates[] = {"text_ft2_source_v2", "text_gdiplus"};
+	const char *candidates[] = {"text_ft2_source_v2", "text_gdiplus"};
 #endif
 
-    obs_source_t *result = nullptr;
-    for (const char *id : candidates) {
-        obs_data_t *child = obs_data_create();
-        obs_data_set_string(child, "text", text_value ? text_value : "");
-        result = obs_source_create_private(id, name, child);
-        obs_data_release(child);
-        if (result) {
-            return result; // Success on first working backend
-        }
-    }
-    blog(LOG_ERROR, "[online-status] Failed to create Text child (%s)", name);
-    return nullptr;
+	obs_source_t *result = nullptr;
+	for (const char *id : candidates) {
+		obs_data_t *child = obs_data_create();
+		obs_data_set_string(child, "text", text_value ? text_value : "");
+		result = obs_source_create_private(id, name, child);
+		obs_data_release(child);
+		if (result) {
+			return result; // Success on first working backend
+		}
+	}
+	blog(LOG_ERROR, "[online-status] Failed to create Text child (%s)", name);
+	return nullptr;
 }
 
 static obs_source_t *create_image_child_raw(const char *name, const char *file_path)
 {
-    obs_data_t *img = obs_data_create();
-    obs_data_set_string(img, "file", file_path ? file_path : "");
-    obs_source_t *result = obs_source_create_private("image_source", name, img);
-    obs_data_release(img);
-    if (!result) {
-        blog(LOG_ERROR, "[online-status] Failed to create Image child (%s)", name);
-    }
-    return result;
+	obs_data_t *img = obs_data_create();
+	obs_data_set_string(img, "file", file_path ? file_path : "");
+	obs_source_t *result = obs_source_create_private("image_source", name, img);
+	obs_data_release(img);
+	if (!result) {
+		blog(LOG_ERROR, "[online-status] Failed to create Image child (%s)", name);
+	}
+	return result;
 }
 
 // ------------------------ Child update helpers ------------------------
 static inline void update_text_child(obs_source_t *child, const std::string &text)
 {
-    if (!child)
-        return;
-    obs_data_t *data = obs_data_create();
-    obs_data_set_string(data, "text", text.c_str());
-    obs_source_update(child, data);
-    obs_data_release(data);
+	if (!child)
+		return;
+	obs_data_t *data = obs_data_create();
+	obs_data_set_string(data, "text", text.c_str());
+	obs_source_update(child, data);
+	obs_data_release(data);
 }
 
 static inline void update_image_child(obs_source_t *child, const std::string &file_path)
 {
-    if (!child)
-        return;
-    obs_data_t *data = obs_data_create();
-    obs_data_set_string(data, "file", file_path.c_str());
-    obs_source_update(child, data);
-    obs_data_release(data);
+	if (!child)
+		return;
+	obs_data_t *data = obs_data_create();
+	obs_data_set_string(data, "file", file_path.c_str());
+	obs_source_update(child, data);
+	obs_data_release(data);
 }
 
 const char *online_status_get_name(void *)
@@ -112,299 +112,298 @@ const char *online_status_get_name(void *)
 void online_status_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_string(settings, "status_text", "");
-    obs_data_set_default_string(settings, "image_path", "");
-    obs_data_set_default_int(settings, "content_mode", 0);
-    // UI section (pseudo-tabs): 0=Dropping,1=Stable,2=Blink,3=Advanced
-    obs_data_set_default_int(settings, "ui_section", 0);
-    // Stable overlay defaults
-    obs_data_set_default_bool(settings, "stable_enabled", true);
-    obs_data_set_default_int(settings, "stable_mode", 0);
-    obs_data_set_default_string(settings, "stable_text", "Connection is stable again");
-    obs_data_set_default_string(settings, "stable_image_path", "");
-    obs_data_set_default_double(settings, "stable_duration_sec", 3.0);
-    obs_data_set_default_double(settings, "drop_threshold_pct", 1.0);
-    obs_data_set_default_double(settings, "hide_after_sec", 3.0);
-    obs_data_set_default_bool(settings, "visible", false);
-    // Advanced test defaults
-    obs_data_set_default_bool(settings, "test_force_drop", false);
-    // Blink defaults (separate)
-    obs_data_set_default_bool(settings, "drop_blink_enabled", false);
-    obs_data_set_default_double(settings, "drop_blink_rate_hz", 1.0);
-    obs_data_set_default_bool(settings, "stable_blink_enabled", false);
-    obs_data_set_default_double(settings, "stable_blink_rate_hz", 1.0);
+	obs_data_set_default_string(settings, "image_path", "");
+	obs_data_set_default_int(settings, "content_mode", 0);
+	// UI section (pseudo-tabs): 0=Dropping,1=Stable,2=Blink,3=Advanced
+	obs_data_set_default_int(settings, "ui_section", 0);
+	// Stable overlay defaults
+	obs_data_set_default_bool(settings, "stable_enabled", true);
+	obs_data_set_default_int(settings, "stable_mode", 0);
+	obs_data_set_default_string(settings, "stable_text", "Connection is stable again");
+	obs_data_set_default_string(settings, "stable_image_path", "");
+	obs_data_set_default_double(settings, "stable_duration_sec", 3.0);
+	obs_data_set_default_double(settings, "drop_threshold_pct", 1.0);
+	obs_data_set_default_double(settings, "hide_after_sec", 3.0);
+	obs_data_set_default_bool(settings, "visible", false);
+	// Advanced test defaults
+	obs_data_set_default_bool(settings, "test_force_drop", false);
+	// Blink defaults (separate)
+	obs_data_set_default_bool(settings, "drop_blink_enabled", false);
+	obs_data_set_default_double(settings, "drop_blink_rate_hz", 1.0);
+	obs_data_set_default_bool(settings, "stable_blink_enabled", false);
+	obs_data_set_default_double(settings, "stable_blink_rate_hz", 1.0);
 }
 
 void online_status_update(void *data, obs_data_t *settings)
 {
 	auto *s = static_cast<OnlineStatus *>(data);
-    s->visible = obs_data_get_bool(settings, "visible");
-    s->content_mode = (int)obs_data_get_int(settings, "content_mode");
+	s->visible = obs_data_get_bool(settings, "visible");
+	s->content_mode = (int)obs_data_get_int(settings, "content_mode");
 	s->drop_threshold_pct = obs_data_get_double(settings, "drop_threshold_pct");
 	s->hide_after_sec = (float)obs_data_get_double(settings, "hide_after_sec");
-    // Advanced test flag
-    s->test_force_drop = obs_data_get_bool(settings, "test_force_drop");
-    // Blink settings (separate)
-    s->drop_blink_enabled = obs_data_get_bool(settings, "drop_blink_enabled");
-    s->drop_blink_rate_hz = obs_data_get_double(settings, "drop_blink_rate_hz");
-    if (s->drop_blink_rate_hz < 0.0)
-        s->drop_blink_rate_hz = 0.0;
-    s->stable_blink_enabled = obs_data_get_bool(settings, "stable_blink_enabled");
-    s->stable_blink_rate_hz = obs_data_get_double(settings, "stable_blink_rate_hz");
-    if (s->stable_blink_rate_hz < 0.0)
-        s->stable_blink_rate_hz = 0.0;
+	// Advanced test flag
+	s->test_force_drop = obs_data_get_bool(settings, "test_force_drop");
+	// Blink settings (separate)
+	s->drop_blink_enabled = obs_data_get_bool(settings, "drop_blink_enabled");
+	s->drop_blink_rate_hz = obs_data_get_double(settings, "drop_blink_rate_hz");
+	if (s->drop_blink_rate_hz < 0.0)
+		s->drop_blink_rate_hz = 0.0;
+	s->stable_blink_enabled = obs_data_get_bool(settings, "stable_blink_enabled");
+	s->stable_blink_rate_hz = obs_data_get_double(settings, "stable_blink_rate_hz");
+	if (s->stable_blink_rate_hz < 0.0)
+		s->stable_blink_rate_hz = 0.0;
 
 	const char *txt = obs_data_get_string(settings, "status_text");
 	s->text = txt ? txt : "";
-    const char *img = obs_data_get_string(settings, "image_path");
-    s->image_path = img ? img : "";
+	const char *img = obs_data_get_string(settings, "image_path");
+	s->image_path = img ? img : "";
 
-    // Stable overlay settings
-    s->stable_enabled = obs_data_get_bool(settings, "stable_enabled");
-    s->stable_mode = (int)obs_data_get_int(settings, "stable_mode");
-    s->stable_duration_sec = (float)obs_data_get_double(settings, "stable_duration_sec");
-    const char *stxt = obs_data_get_string(settings, "stable_text");
-    s->stable_text_msg = stxt ? stxt : "";
-    const char *simg = obs_data_get_string(settings, "stable_image_path");
-    s->stable_image_path = simg ? simg : "";
+	// Stable overlay settings
+	s->stable_enabled = obs_data_get_bool(settings, "stable_enabled");
+	s->stable_mode = (int)obs_data_get_int(settings, "stable_mode");
+	s->stable_duration_sec = (float)obs_data_get_double(settings, "stable_duration_sec");
+	const char *stxt = obs_data_get_string(settings, "stable_text");
+	s->stable_text_msg = stxt ? stxt : "";
+	const char *simg = obs_data_get_string(settings, "stable_image_path");
+	s->stable_image_path = simg ? simg : "";
 
 	// Update dropping children
-    update_text_child(s->status_text.get(), s->text);
-    update_image_child(s->status_image.get(), s->image_path);
+	update_text_child(s->status_text.get(), s->text);
+	update_image_child(s->status_image.get(), s->image_path);
 
-    // Update stable children
-    update_text_child(s->status_text_stable.get(), s->stable_text_msg);
-    update_image_child(s->status_image_stable.get(), s->stable_image_path);
+	// Update stable children
+	update_text_child(s->status_text_stable.get(), s->stable_text_msg);
+	update_image_child(s->status_image_stable.get(), s->stable_image_path);
 
-    // Enable only the active child
-    sync_child_enabled(s);
+	// Enable only the active child
+	sync_child_enabled(s);
 }
 
 void online_status_video_tick(void *data, float seconds)
 {
-    auto *s = static_cast<OnlineStatus *>(data);
-    if (!s)
-        return;
+	auto *s = static_cast<OnlineStatus *>(data);
+	if (!s)
+		return;
 
-    bool streaming_active = false;
-    uint64_t total = 0, dropped = 0;
+	bool streaming_active = false;
+	uint64_t total = 0, dropped = 0;
 
-    obs_output_t *out = obs_frontend_get_streaming_output();
-    if (out) {
-        streaming_active = obs_output_active(out);
-        if (streaming_active) {
-            // Network dropped/total frames
-            dropped = obs_output_get_frames_dropped(out);
-            total = obs_output_get_total_frames(out);
-        }
-        obs_output_release(out);
-    }
+	obs_output_t *out = obs_frontend_get_streaming_output();
+	if (out) {
+		streaming_active = obs_output_active(out);
+		if (streaming_active) {
+			// Network dropped/total frames
+			dropped = obs_output_get_frames_dropped(out);
+			total = obs_output_get_total_frames(out);
+		}
+		obs_output_release(out);
+	}
 
-    bool prev_auto_visible = s->auto_visible;
+	bool prev_auto_visible = s->auto_visible;
 
-    // Test override: force dropping overlay regardless of streaming state
-    if (s->test_force_drop) {
-        s->auto_visible = true;
-        s->since_last_drop = 0.0f;
-        s->stable_visible = false;
-        s->stable_timer = 0.0f;
-    } else if (!streaming_active) {
-        // Not streaming: reset and hide
-        s->prev_total = s->prev_dropped = 0;
-        s->since_last_drop = 0.0f;
-        s->auto_visible = false;
-        s->stable_visible = false;
-        s->stable_timer = 0.0f;
-    } else {
-        // Reset counters if OBS restarted stats
-        if (total < s->prev_total || dropped < s->prev_dropped) {
-            s->prev_total = total;
-            s->prev_dropped = dropped;
-        }
+	// Test override: force dropping overlay regardless of streaming state
+	if (s->test_force_drop) {
+		s->auto_visible = true;
+		s->since_last_drop = 0.0f;
+		s->stable_visible = false;
+		s->stable_timer = 0.0f;
+	} else if (!streaming_active) {
+		// Not streaming: reset and hide
+		s->prev_total = s->prev_dropped = 0;
+		s->since_last_drop = 0.0f;
+		s->auto_visible = false;
+		s->stable_visible = false;
+		s->stable_timer = 0.0f;
+	} else {
+		// Reset counters if OBS restarted stats
+		if (total < s->prev_total || dropped < s->prev_dropped) {
+			s->prev_total = total;
+			s->prev_dropped = dropped;
+		}
 
-        uint64_t d_total = total - s->prev_total;
-        uint64_t d_drop  = dropped - s->prev_dropped;
-        s->prev_total = total;
-        s->prev_dropped = dropped;
+		uint64_t d_total = total - s->prev_total;
+		uint64_t d_drop = dropped - s->prev_dropped;
+		s->prev_total = total;
+		s->prev_dropped = dropped;
 
-        bool spiked = false;
-        if (d_total > 0 && d_drop > 0) {
-            double pct = (double)d_drop * 100.0 / (double)d_total;
-            spiked = (pct >= s->drop_threshold_pct);
-        }
+		bool spiked = false;
+		if (d_total > 0 && d_drop > 0) {
+			double pct = (double)d_drop * 100.0 / (double)d_total;
+			spiked = (pct >= s->drop_threshold_pct);
+		}
 
-        if (spiked) {
-            s->auto_visible = true;
-            s->since_last_drop = 0.0f;
-            // Any new drop cancels stable overlay
-            s->stable_visible = false;
-            s->stable_timer = 0.0f;
-        } else {
-            s->since_last_drop += seconds;
-            if (s->since_last_drop >= s->hide_after_sec) {
-                s->auto_visible = false;
-            }
-        }
+		if (spiked) {
+			s->auto_visible = true;
+			s->since_last_drop = 0.0f;
+			// Any new drop cancels stable overlay
+			s->stable_visible = false;
+			s->stable_timer = 0.0f;
+		} else {
+			s->since_last_drop += seconds;
+			if (s->since_last_drop >= s->hide_after_sec) {
+				s->auto_visible = false;
+			}
+		}
 
-        // Handle transition to stable overlay
-        if (s->stable_enabled) {
-            if (prev_auto_visible && !s->auto_visible) {
-                s->stable_visible = true;
-                s->stable_timer = s->stable_duration_sec;
-            }
-            if (s->stable_visible) {
-                s->stable_timer -= seconds;
-                if (s->stable_timer <= 0.0f) {
-                    s->stable_visible = false;
-                    s->stable_timer = 0.0f;
-                }
-            }
-        } else {
-            s->stable_visible = false;
-            s->stable_timer = 0.0f;
-        }
-    }
+		// Handle transition to stable overlay
+		if (s->stable_enabled) {
+			if (prev_auto_visible && !s->auto_visible) {
+				s->stable_visible = true;
+				s->stable_timer = s->stable_duration_sec;
+			}
+			if (s->stable_visible) {
+				s->stable_timer -= seconds;
+				if (s->stable_timer <= 0.0f) {
+					s->stable_visible = false;
+					s->stable_timer = 0.0f;
+				}
+			}
+		} else {
+			s->stable_visible = false;
+			s->stable_timer = 0.0f;
+		}
+	}
 
-    // Blink update (separate)
-    if (s->drop_blink_enabled && s->drop_blink_rate_hz > 0.0) {
-        const double period_d = 1.0 / s->drop_blink_rate_hz;
-        s->drop_blink_phase += seconds;
-        if (s->drop_blink_phase >= period_d)
-            s->drop_blink_phase = fmod(s->drop_blink_phase, period_d);
-        s->drop_blink_on = (s->drop_blink_phase < (period_d * 0.5));
-    } else {
-        s->drop_blink_on = true;
-        s->drop_blink_phase = 0.0;
-    }
-    if (s->stable_blink_enabled && s->stable_blink_rate_hz > 0.0) {
-        const double period_s = 1.0 / s->stable_blink_rate_hz;
-        s->stable_blink_phase += seconds;
-        if (s->stable_blink_phase >= period_s)
-            s->stable_blink_phase = fmod(s->stable_blink_phase, period_s);
-        s->stable_blink_on = (s->stable_blink_phase < (period_s * 0.5));
-    } else {
-        s->stable_blink_on = true;
-        s->stable_blink_phase = 0.0;
-    }
+	// Blink update (separate)
+	if (s->drop_blink_enabled && s->drop_blink_rate_hz > 0.0) {
+		const double period_d = 1.0 / s->drop_blink_rate_hz;
+		s->drop_blink_phase += seconds;
+		if (s->drop_blink_phase >= period_d)
+			s->drop_blink_phase = fmod(s->drop_blink_phase, period_d);
+		s->drop_blink_on = (s->drop_blink_phase < (period_d * 0.5));
+	} else {
+		s->drop_blink_on = true;
+		s->drop_blink_phase = 0.0;
+	}
+	if (s->stable_blink_enabled && s->stable_blink_rate_hz > 0.0) {
+		const double period_s = 1.0 / s->stable_blink_rate_hz;
+		s->stable_blink_phase += seconds;
+		if (s->stable_blink_phase >= period_s)
+			s->stable_blink_phase = fmod(s->stable_blink_phase, period_s);
+		s->stable_blink_on = (s->stable_blink_phase < (period_s * 0.5));
+	} else {
+		s->stable_blink_on = true;
+		s->stable_blink_phase = 0.0;
+	}
 
-    // Keep children enabled in sync with selected mode, blink and stable state
-    sync_child_enabled(s);
+	// Keep children enabled in sync with selected mode, blink and stable state
+	sync_child_enabled(s);
 }
-
 
 // Create the OnlineStatus instance and its children ( text and image sources )
 void *online_status_create(obs_data_t *settings, obs_source_t *owner)
 {
-    UNUSED_PARAMETER(owner);
-    auto *s = new OnlineStatus();
+	UNUSED_PARAMETER(owner);
+	auto *s = new OnlineStatus();
 
-    const char *drop_text   = obs_data_get_string(settings, "status_text");
-    const char *drop_image  = obs_data_get_string(settings, "image_path");
-    const char *stable_text = obs_data_get_string(settings, "stable_text");
-    const char *stable_img  = obs_data_get_string(settings, "stable_image_path");
+	const char *drop_text = obs_data_get_string(settings, "status_text");
+	const char *drop_image = obs_data_get_string(settings, "image_path");
+	const char *stable_text = obs_data_get_string(settings, "stable_text");
+	const char *stable_img = obs_data_get_string(settings, "stable_image_path");
 
-    // Create dropping children
-    s->status_text.reset(create_text_child_raw("online-status:text", drop_text));
-    s->status_image.reset(create_image_child_raw("online-status:image", drop_image));
+	// Create dropping children
+	s->status_text.reset(create_text_child_raw("online-status:text", drop_text));
+	s->status_image.reset(create_image_child_raw("online-status:image", drop_image));
 
-    // Create stable children
-    s->status_text_stable.reset(create_text_child_raw("online-status:text-stable", stable_text));
-    s->status_image_stable.reset(create_image_child_raw("online-status:image-stable", stable_img));
+	// Create stable children
+	s->status_text_stable.reset(create_text_child_raw("online-status:text-stable", stable_text));
+	s->status_image_stable.reset(create_image_child_raw("online-status:image-stable", stable_img));
 
-    online_status_update(s, settings);
-    return s;
+	online_status_update(s, settings);
+	return s;
 }
 
 void online_status_destroy(void *data)
 {
 	auto *s = static_cast<OnlineStatus *>(data);
-    delete s; // smart pointers release automatically
+	delete s; // smart pointers release automatically
 }
 uint32_t online_status_get_width(void *data)
 {
 	auto *s = static_cast<OnlineStatus *>(data);
-    if (!s)
-        return 0;
-    const bool show_alert = should_show_dropping(s);
-    const bool show_stable = should_show_stable(s);
-    if (show_alert) {
-        if (s->content_mode == 1 && s->status_image.get())
-            return obs_source_get_width(s->status_image.get());
-        return s->status_text.get() ? obs_source_get_width(s->status_text.get()) : 0;
-    }
-    if (show_stable) {
-        if (s->stable_mode == 1 && s->status_image_stable.get())
-            return obs_source_get_width(s->status_image_stable.get());
-        return s->status_text_stable.get() ? obs_source_get_width(s->status_text_stable.get()) : 0;
-    }
-    // Fallback to dropping-mode size
-    if (s->content_mode == 1 && s->status_image.get())
-        return obs_source_get_width(s->status_image.get());
-    return s->status_text.get() ? obs_source_get_width(s->status_text.get()) : 0;
+	if (!s)
+		return 0;
+	const bool show_alert = should_show_dropping(s);
+	const bool show_stable = should_show_stable(s);
+	if (show_alert) {
+		if (s->content_mode == 1 && s->status_image.get())
+			return obs_source_get_width(s->status_image.get());
+		return s->status_text.get() ? obs_source_get_width(s->status_text.get()) : 0;
+	}
+	if (show_stable) {
+		if (s->stable_mode == 1 && s->status_image_stable.get())
+			return obs_source_get_width(s->status_image_stable.get());
+		return s->status_text_stable.get() ? obs_source_get_width(s->status_text_stable.get()) : 0;
+	}
+	// Fallback to dropping-mode size
+	if (s->content_mode == 1 && s->status_image.get())
+		return obs_source_get_width(s->status_image.get());
+	return s->status_text.get() ? obs_source_get_width(s->status_text.get()) : 0;
 }
 
 uint32_t online_status_get_height(void *data)
 {
 	auto *s = static_cast<OnlineStatus *>(data);
-    if (!s)
-        return 0;
-    const bool show_alert = should_show_dropping(s);
-    const bool show_stable = should_show_stable(s);
-    if (show_alert) {
-        if (s->content_mode == 1 && s->status_image.get())
-            return obs_source_get_height(s->status_image.get());
-        return s->status_text.get() ? obs_source_get_height(s->status_text.get()) : 0;
-    }
-    if (show_stable) {
-        if (s->stable_mode == 1 && s->status_image_stable.get())
-            return obs_source_get_height(s->status_image_stable.get());
-        return s->status_text_stable.get() ? obs_source_get_height(s->status_text_stable.get()) : 0;
-    }
-    if (s->content_mode == 1 && s->status_image.get())
-        return obs_source_get_height(s->status_image.get());
-    return s->status_text.get() ? obs_source_get_height(s->status_text.get()) : 0;
+	if (!s)
+		return 0;
+	const bool show_alert = should_show_dropping(s);
+	const bool show_stable = should_show_stable(s);
+	if (show_alert) {
+		if (s->content_mode == 1 && s->status_image.get())
+			return obs_source_get_height(s->status_image.get());
+		return s->status_text.get() ? obs_source_get_height(s->status_text.get()) : 0;
+	}
+	if (show_stable) {
+		if (s->stable_mode == 1 && s->status_image_stable.get())
+			return obs_source_get_height(s->status_image_stable.get());
+		return s->status_text_stable.get() ? obs_source_get_height(s->status_text_stable.get()) : 0;
+	}
+	if (s->content_mode == 1 && s->status_image.get())
+		return obs_source_get_height(s->status_image.get());
+	return s->status_text.get() ? obs_source_get_height(s->status_text.get()) : 0;
 }
 void online_status_video_render(void *data, gs_effect_t * /*effect*/)
 {
 	auto *s = static_cast<OnlineStatus *>(data);
-    if (!s)
-        return;
-    if (should_show_dropping(s)) {
-        if (s->content_mode == 1) {
-            if (s->status_image.get())
-                obs_source_video_render(s->status_image.get());
-        } else {
-            if (s->status_text.get())
-                obs_source_video_render(s->status_text.get());
-        }
-        return;
-    }
-    if (should_show_stable(s)) {
-        if (s->stable_mode == 1) {
-            if (s->status_image_stable.get())
-                obs_source_video_render(s->status_image_stable.get());
-        } else {
-            if (s->status_text_stable.get())
-                obs_source_video_render(s->status_text_stable.get());
-        }
-    }
+	if (!s)
+		return;
+	if (should_show_dropping(s)) {
+		if (s->content_mode == 1) {
+			if (s->status_image.get())
+				obs_source_video_render(s->status_image.get());
+		} else {
+			if (s->status_text.get())
+				obs_source_video_render(s->status_text.get());
+		}
+		return;
+	}
+	if (should_show_stable(s)) {
+		if (s->stable_mode == 1) {
+			if (s->status_image_stable.get())
+				obs_source_video_render(s->status_image_stable.get());
+		} else {
+			if (s->status_text_stable.get())
+				obs_source_video_render(s->status_text_stable.get());
+		}
+	}
 }
 
 // online_status_properties is implemented in properties translation unit
 
 static obs_source_info online_status_info = {
-    .id = "online-status",
-    .type = OBS_SOURCE_TYPE_INPUT,
-    .output_flags = OBS_SOURCE_VIDEO,
-    .get_name = online_status_get_name,
-    .create = online_status_create,
-    .destroy = online_status_destroy,
-    .get_width = online_status_get_width,
-    .get_height = online_status_get_height,
-    .get_defaults = online_status_defaults,
-    .get_properties = online_status_properties,
-    .update = online_status_update,
-    .video_tick = online_status_video_tick,    // <- add tick
-    .video_render = online_status_video_render,
+	.id = "online-status",
+	.type = OBS_SOURCE_TYPE_INPUT,
+	.output_flags = OBS_SOURCE_VIDEO,
+	.get_name = online_status_get_name,
+	.create = online_status_create,
+	.destroy = online_status_destroy,
+	.get_width = online_status_get_width,
+	.get_height = online_status_get_height,
+	.get_defaults = online_status_defaults,
+	.get_properties = online_status_properties,
+	.update = online_status_update,
+	.video_tick = online_status_video_tick, // <- add tick
+	.video_render = online_status_video_render,
 };
 
 void register_online_status_source(void)

--- a/src/online-status.cpp
+++ b/src/online-status.cpp
@@ -1,18 +1,101 @@
-/*
-    Show an image or text when the streamer is having connection problems or dropping frames
-*/
-
+// Order includes so OBS types are visible before we declare callbacks
 #include <obs-module.h>
 #include <plugin-support.h>
 #include <obs-frontend-api.h>
 #include <string>
 #include <cmath>
+#include <utility>
+
+// Property UI visibility refresher (C-callable for OBS callbacks)
+static bool online_status_properties_refresh(obs_properties_t *props, obs_property_t * /*property*/, obs_data_t *settings)
+{
+    auto set_vis = [&](const char *name, bool v) {
+        if (obs_property_t *pp = obs_properties_get(props, name))
+            obs_property_set_visible(pp, v);
+    };
+
+    int section = (int)obs_data_get_int(settings, "ui_section");
+    int mode_val = (int)obs_data_get_int(settings, "content_mode");
+
+    // Dropping group inner properties
+    if (obs_property_t *grp = obs_properties_get(props, "dropping_group")) {
+        obs_properties_t *inner = obs_property_group_content(grp);
+        if (inner) {
+            bool show_drop = (section == 0);
+            if (obs_property_t *pp = obs_properties_get(inner, "content_mode"))
+                obs_property_set_visible(pp, show_drop);
+            if (obs_property_t *pp = obs_properties_get(inner, "status_text"))
+                obs_property_set_visible(pp, show_drop && mode_val == 0);
+            if (obs_property_t *pp = obs_properties_get(inner, "image_path"))
+                obs_property_set_visible(pp, show_drop && mode_val == 1);
+            if (obs_property_t *pp = obs_properties_get(inner, "drop_threshold_pct"))
+                obs_property_set_visible(pp, show_drop);
+            if (obs_property_t *pp = obs_properties_get(inner, "hide_after_sec"))
+                obs_property_set_visible(pp, show_drop);
+            if (obs_property_t *pp = obs_properties_get(inner, "drop_blink_enabled"))
+                obs_property_set_visible(pp, show_drop);
+            if (obs_property_t *pp = obs_properties_get(inner, "drop_blink_rate_hz"))
+                obs_property_set_visible(pp, show_drop);
+        }
+    }
+
+    // Stable group inner properties
+    if (obs_property_t *grp = obs_properties_get(props, "stable_group")) {
+        obs_properties_t *inner = obs_property_group_content(grp);
+        if (inner) {
+            bool s_enabled_v = obs_data_get_bool(settings, "stable_enabled");
+            int s_mode = (int)obs_data_get_int(settings, "stable_mode");
+            bool show_inner = (section == 1) && s_enabled_v;
+
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_mode"))
+                obs_property_set_visible(pp, section == 1);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_text"))
+                obs_property_set_visible(pp, show_inner && s_mode == 0);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_image_path"))
+                obs_property_set_visible(pp, show_inner && s_mode == 1);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_enabled"))
+                obs_property_set_visible(pp, section == 1);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_duration_sec"))
+                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_blink_enabled"))
+                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_blink_rate_hz"))
+                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+        }
+    }
+
+    // Pseudo-tabs visibility (no separate Blink tab)
+    bool show_dropping = (section == 0);
+    bool show_stable   = (section == 1);
+    bool show_adv      = (section == 2);
+
+    set_vis("visible", show_adv);
+    set_vis("test_force_drop", show_adv);
+    set_vis("test_simulate_spike", show_adv);
+    set_vis("test_show_stable", show_adv);
+    set_vis("test_hide_all", show_adv);
+
+    if (obs_property_t *grp = obs_properties_get(props, "dropping_group"))
+        obs_property_set_visible(grp, show_dropping);
+    if (obs_property_t *grp = obs_properties_get(props, "stable_group"))
+        obs_property_set_visible(grp, show_stable);
+    return true;
+}
+/*
+    Show an image or text when the streamer is having connection problems or dropping frames
+*/
 
 struct OnlineStatus {
 	obs_source_t *status_text = nullptr;
 	obs_source_t *status_image = nullptr;
+	// Stable-state children
+	obs_source_t *status_text_stable = nullptr;
+	obs_source_t *status_image_stable = nullptr;
 	std::string text;
     std::string image_path;
+    // Stable content
+    std::string stable_text_msg;
+    std::string stable_image_path;
     bool visible = false;
     bool auto_visible = false;
     int content_mode = 0; // 0 = text, 1 = image
@@ -22,11 +105,25 @@ struct OnlineStatus {
     uint64_t prev_dropped = 0;
     float since_last_drop = 0.0f;
 
-    // Blink config/state
-    bool blink_enabled = false;
-    double blink_rate_hz = 1.0; // blinks per second
-    double blink_phase = 0.0;   // seconds into current period
-    bool blink_on = true;       // current half-cycle visible?
+    // Blink config/state (separate for dropping and stable overlays)
+    bool drop_blink_enabled = false;
+    double drop_blink_rate_hz = 1.0; // blinks per second
+    double drop_blink_phase = 0.0;   // seconds into current period
+    bool drop_blink_on = true;       // current half-cycle visible?
+
+    bool stable_blink_enabled = false;
+    double stable_blink_rate_hz = 1.0;
+    double stable_blink_phase = 0.0;
+    bool stable_blink_on = true;
+
+    // Stable overlay options/state
+    bool  stable_enabled = true;
+    int   stable_mode = 0;            // 0=text, 1=image
+    float stable_duration_sec = 3.0f; // how long to show after recovery
+    float stable_timer = 0.0f;
+    bool  stable_visible = false;
+    // Testing helpers
+    bool  test_force_drop = false;
 };
 
 static const char *online_status_get_name(void *)
@@ -39,12 +136,24 @@ static void online_status_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, "status_text", "");
     obs_data_set_default_string(settings, "image_path", "");
     obs_data_set_default_int(settings, "content_mode", 0);
+    // UI section (pseudo-tabs): 0=Dropping,1=Stable,2=Blink,3=Advanced
+    obs_data_set_default_int(settings, "ui_section", 0);
+    // Stable overlay defaults
+    obs_data_set_default_bool(settings, "stable_enabled", true);
+    obs_data_set_default_int(settings, "stable_mode", 0);
+    obs_data_set_default_string(settings, "stable_text", "Connection is stable again");
+    obs_data_set_default_string(settings, "stable_image_path", "");
+    obs_data_set_default_double(settings, "stable_duration_sec", 3.0);
     obs_data_set_default_double(settings, "drop_threshold_pct", 1.0);
     obs_data_set_default_double(settings, "hide_after_sec", 3.0);
     obs_data_set_default_bool(settings, "visible", false);
-    // Blink defaults
-    obs_data_set_default_bool(settings, "blink_enabled", false);
-    obs_data_set_default_double(settings, "blink_rate_hz", 1.0);
+    // Advanced test defaults
+    obs_data_set_default_bool(settings, "test_force_drop", false);
+    // Blink defaults (separate)
+    obs_data_set_default_bool(settings, "drop_blink_enabled", false);
+    obs_data_set_default_double(settings, "drop_blink_rate_hz", 1.0);
+    obs_data_set_default_bool(settings, "stable_blink_enabled", false);
+    obs_data_set_default_double(settings, "stable_blink_rate_hz", 1.0);
 }
 
 static void online_status_update(void *data, obs_data_t *settings)
@@ -55,16 +164,29 @@ static void online_status_update(void *data, obs_data_t *settings)
     s->content_mode = (int)obs_data_get_int(settings, "content_mode");
 	s->drop_threshold_pct = obs_data_get_double(settings, "drop_threshold_pct");
 	s->hide_after_sec = (float)obs_data_get_double(settings, "hide_after_sec");
-    // Blink settings
-    s->blink_enabled = obs_data_get_bool(settings, "blink_enabled");
-    s->blink_rate_hz = obs_data_get_double(settings, "blink_rate_hz");
-    if (s->blink_rate_hz < 0.0)
-        s->blink_rate_hz = 0.0;
+    // Blink settings (separate)
+    s->drop_blink_enabled = obs_data_get_bool(settings, "drop_blink_enabled");
+    s->drop_blink_rate_hz = obs_data_get_double(settings, "drop_blink_rate_hz");
+    if (s->drop_blink_rate_hz < 0.0)
+        s->drop_blink_rate_hz = 0.0;
+    s->stable_blink_enabled = obs_data_get_bool(settings, "stable_blink_enabled");
+    s->stable_blink_rate_hz = obs_data_get_double(settings, "stable_blink_rate_hz");
+    if (s->stable_blink_rate_hz < 0.0)
+        s->stable_blink_rate_hz = 0.0;
 
 	const char *txt = obs_data_get_string(settings, "status_text");
 	s->text = txt ? txt : "";
     const char *img = obs_data_get_string(settings, "image_path");
     s->image_path = img ? img : "";
+
+    // Stable overlay settings
+    s->stable_enabled = obs_data_get_bool(settings, "stable_enabled");
+    s->stable_mode = (int)obs_data_get_int(settings, "stable_mode");
+    s->stable_duration_sec = (float)obs_data_get_double(settings, "stable_duration_sec");
+    const char *stxt = obs_data_get_string(settings, "stable_text");
+    s->stable_text_msg = stxt ? stxt : "";
+    const char *simg = obs_data_get_string(settings, "stable_image_path");
+    s->stable_image_path = simg ? simg : "";
 
 	if (s->status_text) {
 		obs_data_t *child = obs_data_create();
@@ -82,12 +204,33 @@ static void online_status_update(void *data, obs_data_t *settings)
         obs_data_release(imgset);
 	}
 
-    const bool effective_visible = (s->auto_visible || s->visible);
+    // Update stable children
+    if (s->status_text_stable) {
+        obs_data_t *child = obs_data_create();
+        obs_data_set_string(child, "text", s->stable_text_msg.c_str());
+        obs_source_update(s->status_text_stable, child);
+        obs_data_release(child);
+    }
+    if (s->status_image_stable) {
+        obs_data_t *imgset = obs_data_create();
+        obs_data_set_string(imgset, "file", s->stable_image_path.c_str());
+        obs_source_update(s->status_image_stable, imgset);
+        obs_data_release(imgset);
+    }
+
+    const bool drop_blink_ok = (!s->drop_blink_enabled || s->drop_blink_on);
+    const bool stable_blink_ok = (!s->stable_blink_enabled || s->stable_blink_on);
+    const bool show_alert = (s->auto_visible || s->visible) && drop_blink_ok;
+    const bool show_stable = s->stable_visible && s->stable_enabled && stable_blink_ok;
     // Enable only the active child
     if (s->status_text)
-        obs_source_set_enabled(s->status_text, effective_visible && s->content_mode == 0);
+        obs_source_set_enabled(s->status_text, show_alert && s->content_mode == 0);
     if (s->status_image)
-        obs_source_set_enabled(s->status_image, effective_visible && s->content_mode == 1);
+        obs_source_set_enabled(s->status_image, show_alert && s->content_mode == 1);
+    if (s->status_text_stable)
+        obs_source_set_enabled(s->status_text_stable, show_stable && s->stable_mode == 0);
+    if (s->status_image_stable)
+        obs_source_set_enabled(s->status_image_stable, show_stable && s->stable_mode == 1);
 }
 
 static void online_status_video_tick(void *data, float seconds)
@@ -110,11 +253,21 @@ static void online_status_video_tick(void *data, float seconds)
         obs_output_release(out);
     }
 
-    if (!streaming_active) {
+    bool prev_auto_visible = s->auto_visible;
+
+    // Test override: force dropping overlay regardless of streaming state
+    if (s->test_force_drop) {
+        s->auto_visible = true;
+        s->since_last_drop = 0.0f;
+        s->stable_visible = false;
+        s->stable_timer = 0.0f;
+    } else if (!streaming_active) {
         // Not streaming: reset and hide
         s->prev_total = s->prev_dropped = 0;
         s->since_last_drop = 0.0f;
         s->auto_visible = false;
+        s->stable_visible = false;
+        s->stable_timer = 0.0f;
     } else {
         // Reset counters if OBS restarted stats
         if (total < s->prev_total || dropped < s->prev_dropped) {
@@ -136,33 +289,102 @@ static void online_status_video_tick(void *data, float seconds)
         if (spiked) {
             s->auto_visible = true;
             s->since_last_drop = 0.0f;
+            // Any new drop cancels stable overlay
+            s->stable_visible = false;
+            s->stable_timer = 0.0f;
         } else {
             s->since_last_drop += seconds;
             if (s->since_last_drop >= s->hide_after_sec) {
                 s->auto_visible = false;
             }
         }
+
+        // Handle transition to stable overlay
+        if (s->stable_enabled) {
+            if (prev_auto_visible && !s->auto_visible) {
+                s->stable_visible = true;
+                s->stable_timer = s->stable_duration_sec;
+            }
+            if (s->stable_visible) {
+                s->stable_timer -= seconds;
+                if (s->stable_timer <= 0.0f) {
+                    s->stable_visible = false;
+                    s->stable_timer = 0.0f;
+                }
+            }
+        } else {
+            s->stable_visible = false;
+            s->stable_timer = 0.0f;
+        }
     }
 
-    // Blink update
-    if (s->blink_enabled && s->blink_rate_hz > 0.0) {
-        const double period = 1.0 / s->blink_rate_hz;
-        s->blink_phase += seconds;
-        if (s->blink_phase >= period)
-            s->blink_phase = fmod(s->blink_phase, period);
-        // 50% duty cycle: visible in first half of the period
-        s->blink_on = (s->blink_phase < (period * 0.5));
+    // Blink update (separate)
+    if (s->drop_blink_enabled && s->drop_blink_rate_hz > 0.0) {
+        const double period_d = 1.0 / s->drop_blink_rate_hz;
+        s->drop_blink_phase += seconds;
+        if (s->drop_blink_phase >= period_d)
+            s->drop_blink_phase = fmod(s->drop_blink_phase, period_d);
+        s->drop_blink_on = (s->drop_blink_phase < (period_d * 0.5));
     } else {
-        s->blink_on = true;
-        s->blink_phase = 0.0;
+        s->drop_blink_on = true;
+        s->drop_blink_phase = 0.0;
+    }
+    if (s->stable_blink_enabled && s->stable_blink_rate_hz > 0.0) {
+        const double period_s = 1.0 / s->stable_blink_rate_hz;
+        s->stable_blink_phase += seconds;
+        if (s->stable_blink_phase >= period_s)
+            s->stable_blink_phase = fmod(s->stable_blink_phase, period_s);
+        s->stable_blink_on = (s->stable_blink_phase < (period_s * 0.5));
+    } else {
+        s->stable_blink_on = true;
+        s->stable_blink_phase = 0.0;
     }
 
-    // Keep children enabled in sync with selected mode and blink
-    const bool effective_visible = (s->auto_visible || s->visible) && (!s->blink_enabled || s->blink_on);
+    // Keep children enabled in sync with selected mode, blink and stable state
+    const bool blink_ok2_drop = (!s->drop_blink_enabled || s->drop_blink_on);
+    const bool blink_ok2_stable = (!s->stable_blink_enabled || s->stable_blink_on);
+    const bool show_alert2 = (s->auto_visible || s->visible) && blink_ok2_drop;
+    const bool show_stable2 = s->stable_visible && s->stable_enabled && blink_ok2_stable;
     if (s->status_text)
-        obs_source_set_enabled(s->status_text, effective_visible && s->content_mode == 0);
+        obs_source_set_enabled(s->status_text, show_alert2 && s->content_mode == 0);
     if (s->status_image)
-        obs_source_set_enabled(s->status_image, effective_visible && s->content_mode == 1);
+        obs_source_set_enabled(s->status_image, show_alert2 && s->content_mode == 1);
+    if (s->status_text_stable)
+        obs_source_set_enabled(s->status_text_stable, show_stable2 && s->stable_mode == 0);
+    if (s->status_image_stable)
+        obs_source_set_enabled(s->status_image_stable, show_stable2 && s->stable_mode == 1);
+}
+
+// Advanced testing buttons
+static bool online_status_btn_simulate_spike(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
+{
+    auto *s = static_cast<OnlineStatus *>(data);
+    if (!s) return false;
+    s->auto_visible = true;
+    s->since_last_drop = 0.0f;
+    s->stable_visible = false;
+    s->stable_timer = 0.0f;
+    return true; // refresh UI
+}
+
+static bool online_status_btn_show_stable(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
+{
+    auto *s = static_cast<OnlineStatus *>(data);
+    if (!s) return false;
+    s->auto_visible = false;
+    s->stable_visible = true;
+    s->stable_timer = s->stable_duration_sec;
+    return true;
+}
+
+static bool online_status_btn_hide_all(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
+{
+    auto *s = static_cast<OnlineStatus *>(data);
+    if (!s) return false;
+    s->auto_visible = false;
+    s->stable_visible = false;
+    s->stable_timer = 0.0f;
+    return true;
 }
 
 static void *online_status_create(obs_data_t *settings, obs_source_t *owner)
@@ -207,6 +429,36 @@ static void *online_status_create(obs_data_t *settings, obs_source_t *owner)
         blog(LOG_ERROR, "[online-status] Failed to create Image child (id=image_source)");
     }
 
+    // Create stable children
+    obs_data_t *stable_text = obs_data_create();
+    obs_data_set_string(stable_text, "text", obs_data_get_string(settings, "stable_text"));
+    const char *stable_text_id = "text_ft2_source_v2";
+#ifdef _WIN32
+    stable_text_id = "text_gdiplus";
+#endif
+    s->status_text_stable = obs_source_create_private(stable_text_id, "online-status:text-stable", stable_text);
+    if (!s->status_text_stable) {
+        const char *fallback_id2 =
+#ifdef _WIN32
+            "text_ft2_source_v2";
+#else
+            "text_gdiplus";
+#endif
+        s->status_text_stable = obs_source_create_private(fallback_id2, "online-status:text-stable", stable_text);
+        if (!s->status_text_stable) {
+            blog(LOG_ERROR, "[online-status] Failed to create Stable Text child (tried %s then %s)", stable_text_id, fallback_id2);
+        }
+    }
+    obs_data_release(stable_text);
+
+    obs_data_t *stable_img = obs_data_create();
+    obs_data_set_string(stable_img, "file", obs_data_get_string(settings, "stable_image_path"));
+    s->status_image_stable = obs_source_create_private("image_source", "online-status:image-stable", stable_img);
+    obs_data_release(stable_img);
+    if (!s->status_image_stable) {
+        blog(LOG_ERROR, "[online-status] Failed to create Stable Image child");
+    }
+
 	online_status_update(s, settings);
 	return s;
 }
@@ -223,6 +475,14 @@ static void online_status_destroy(void *data)
             obs_source_release(s->status_image);
             s->status_image = nullptr;
         }
+        if (s->status_text_stable) {
+            obs_source_release(s->status_text_stable);
+            s->status_text_stable = nullptr;
+        }
+        if (s->status_image_stable) {
+            obs_source_release(s->status_image_stable);
+            s->status_image_stable = nullptr;
+        }
 		delete s;
 	}
 }
@@ -231,9 +491,24 @@ static uint32_t online_status_get_width(void *data)
 	auto *s = static_cast<OnlineStatus *>(data);
     if (!s)
         return 0;
+    const bool drop_blink_ok = (!s->drop_blink_enabled || s->drop_blink_on);
+    const bool stable_blink_ok = (!s->stable_blink_enabled || s->stable_blink_on);
+    const bool show_alert = (s->auto_visible || s->visible) && drop_blink_ok;
+    const bool show_stable = s->stable_visible && s->stable_enabled && stable_blink_ok;
+    if (show_alert) {
+        if (s->content_mode == 1 && s->status_image)
+            return obs_source_get_width(s->status_image);
+        return s->status_text ? obs_source_get_width(s->status_text) : 0;
+    }
+    if (show_stable) {
+        if (s->stable_mode == 1 && s->status_image_stable)
+            return obs_source_get_width(s->status_image_stable);
+        return s->status_text_stable ? obs_source_get_width(s->status_text_stable) : 0;
+    }
+    // Fallback to dropping-mode size
     if (s->content_mode == 1 && s->status_image)
         return obs_source_get_width(s->status_image);
-	return s->status_text ? obs_source_get_width(s->status_text) : 0;
+    return s->status_text ? obs_source_get_width(s->status_text) : 0;
 }
 
 static uint32_t online_status_get_height(void *data)
@@ -241,49 +516,134 @@ static uint32_t online_status_get_height(void *data)
 	auto *s = static_cast<OnlineStatus *>(data);
     if (!s)
         return 0;
+    const bool drop_blink_ok = (!s->drop_blink_enabled || s->drop_blink_on);
+    const bool stable_blink_ok = (!s->stable_blink_enabled || s->stable_blink_on);
+    const bool show_alert = (s->auto_visible || s->visible) && drop_blink_ok;
+    const bool show_stable = s->stable_visible && s->stable_enabled && stable_blink_ok;
+    if (show_alert) {
+        if (s->content_mode == 1 && s->status_image)
+            return obs_source_get_height(s->status_image);
+        return s->status_text ? obs_source_get_height(s->status_text) : 0;
+    }
+    if (show_stable) {
+        if (s->stable_mode == 1 && s->status_image_stable)
+            return obs_source_get_height(s->status_image_stable);
+        return s->status_text_stable ? obs_source_get_height(s->status_text_stable) : 0;
+    }
     if (s->content_mode == 1 && s->status_image)
         return obs_source_get_height(s->status_image);
-	return s->status_text ? obs_source_get_height(s->status_text) : 0;
+    return s->status_text ? obs_source_get_height(s->status_text) : 0;
 }
 static void online_status_video_render(void *data, gs_effect_t * /*effect*/)
 {
 	auto *s = static_cast<OnlineStatus *>(data);
     if (!s)
         return;
-    const bool effective_visible = (s->auto_visible || s->visible) && (!s->blink_enabled || s->blink_on);
-    if (!effective_visible)
+    const bool drop_blink_ok = (!s->drop_blink_enabled || s->drop_blink_on);
+    if ((s->auto_visible || s->visible) && drop_blink_ok) {
+        if (s->content_mode == 1) {
+            if (s->status_image)
+                obs_source_video_render(s->status_image);
+        } else {
+            if (s->status_text)
+                obs_source_video_render(s->status_text);
+        }
         return;
-
-    if (s->content_mode == 1) {
-        if (s->status_image)
-            obs_source_video_render(s->status_image);
-    } else {
-        if (s->status_text)
-            obs_source_video_render(s->status_text);
+    }
+    const bool stable_blink_ok = (!s->stable_blink_enabled || s->stable_blink_on);
+    if (s->stable_visible && s->stable_enabled && stable_blink_ok) {
+        if (s->stable_mode == 1) {
+            if (s->status_image_stable)
+                obs_source_video_render(s->status_image_stable);
+        } else {
+            if (s->status_text_stable)
+                obs_source_video_render(s->status_text_stable);
+        }
     }
 }
 
-static obs_properties_t *online_status_properties(void * /*data*/)
+static obs_properties_t *online_status_properties(void *data)
 {
+    UNUSED_PARAMETER(data);
 	obs_properties_t *props = obs_properties_create();
 
-    // Mode selector
-    obs_property_t *mode = obs_properties_add_list(props, "content_mode", "Content Type",
+    // Section selector to simulate tabs
+    obs_property_t *section = obs_properties_add_list(
+        props, "ui_section", "Section",
+        OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+    obs_property_list_add_int(section, "Dropping", 0);
+    obs_property_list_add_int(section, "Stable", 1);
+    obs_property_list_add_int(section, "Advanced", 2);
+
+    // Dropping overlay group
+    obs_properties_t *dropping = obs_properties_create();
+    obs_property_t *mode = obs_properties_add_list(dropping, "content_mode", "Content Type (when dropping)",
                                                    OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
     obs_property_list_add_int(mode, "Text", 0);
     obs_property_list_add_int(mode, "Image", 1);
 
-	obs_properties_add_text(props, "status_text", "Enter the status text to display", OBS_TEXT_DEFAULT);
-    obs_properties_add_path(props, "image_path", "Image file", OBS_PATH_FILE,
+	obs_properties_add_text(dropping, "status_text", "Text to show while dropping", OBS_TEXT_DEFAULT);
+    obs_properties_add_path(dropping, "image_path", "Image file (while dropping)", OBS_PATH_FILE,
                             "Image files (*.png *.jpg *.jpeg *.bmp *.gif);;All files (*.*)", nullptr);
 
-	obs_properties_add_float_slider(props, "drop_threshold_pct", "Drop % threshold (per-interval)", 0.0, 100.0,
+	obs_properties_add_float_slider(dropping, "drop_threshold_pct", "Drop % threshold (per-interval)", 0.0, 100.0,
         0.1);
-    obs_properties_add_float_slider(props, "hide_after_sec", "Hide after seconds without drops", 0.0, 30.0, 0.1);
+    obs_properties_add_float_slider(dropping, "hide_after_sec", "Hide after seconds without drops", 0.0, 30.0, 0.1);
+    // Blink controls (Dropping)
+    obs_properties_add_bool(dropping, "drop_blink_enabled", "Blink (while dropping)");
+    obs_properties_add_float_slider(dropping, "drop_blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
+
+    obs_property_t *dropping_group = obs_properties_add_group(props, "dropping_group", "When dropping frames",
+                                                             OBS_GROUP_NORMAL, dropping);
     obs_properties_add_bool(props, "visible", "Test text that auto-shows when dropping frames(for debugging)");
-    // Blink controls
-    obs_properties_add_bool(props, "blink_enabled", "Blink");
-    obs_properties_add_float_slider(props, "blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
+
+    // Stable overlay group
+    obs_properties_t *stable = obs_properties_create();
+    obs_properties_add_bool(stable, "stable_enabled", "Show message when connection is stable");
+    obs_property_t *smode = obs_properties_add_list(stable, "stable_mode", "Content Type (when stable)",
+                                                    OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+    obs_property_list_add_int(smode, "Text", 0);
+    obs_property_list_add_int(smode, "Image", 1);
+    obs_properties_add_text(stable, "stable_text", "Stable text", OBS_TEXT_DEFAULT);
+    obs_properties_add_path(stable, "stable_image_path", "Stable image file", OBS_PATH_FILE,
+                            "Image files (*.png *.jpg *.jpeg *.bmp *.gif);;All files (*.*)", nullptr);
+    obs_properties_add_float_slider(stable, "stable_duration_sec", "Stable message duration (seconds)",
+                                    0.0, 60.0, 0.1);
+    // Blink controls (Stable)
+    obs_properties_add_bool(stable, "stable_blink_enabled", "Blink (stable message)");
+    obs_properties_add_float_slider(stable, "stable_blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
+
+    obs_property_t *stable_group = obs_properties_add_group(props, "stable_group", "When connection stabilizes", OBS_GROUP_NORMAL, stable);
+
+    // Advanced: testing controls
+    obs_properties_add_bool(props, "test_force_drop", "Test: Force dropping overlay");
+    obs_properties_add_button(props, "test_simulate_spike", "Test: Simulate drop spike", online_status_btn_simulate_spike);
+    obs_properties_add_button(props, "test_show_stable", "Test: Show stable message now", online_status_btn_show_stable);
+    obs_properties_add_button(props, "test_hide_all", "Test: Hide overlays", online_status_btn_hide_all);
+
+    // Dynamic visibility handled by C-callback online_status_properties_refresh()
+
+    // Hook callbacks
+    obs_property_set_modified_callback(section, online_status_properties_refresh);
+    obs_property_set_modified_callback(mode,    online_status_properties_refresh);
+    // Hook inner dropping toggles
+    if (obs_property_t *grp = dropping_group) {
+        obs_properties_t *inner = obs_property_group_content(grp);
+        if (inner) {
+            if (obs_property_t *pp = obs_properties_get(inner, "content_mode"))
+                obs_property_set_modified_callback(pp, online_status_properties_refresh);
+        }
+    }
+    // Also attach to stable group inner toggles
+    if (obs_property_t *grp = stable_group) {
+        obs_properties_t *inner = obs_property_group_content(grp);
+        if (inner) {
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_enabled"))
+                obs_property_set_modified_callback(pp, online_status_properties_refresh);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_mode"))
+                obs_property_set_modified_callback(pp, online_status_properties_refresh);
+        }
+    }
 	return props;
 }
 

--- a/src/online-status.cpp
+++ b/src/online-status.cpp
@@ -1,6 +1,7 @@
 // Order includes so OBS types are visible before we declare callbacks
 #include "online_status.hpp"
 #include <string>
+#include <obs-frontend-api.h>
 #include <cmath>
 #include <utility>
 

--- a/src/online_status.hpp
+++ b/src/online_status.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <obs-module.h>
-#include <obs-frontend-api.h>
 #include <plugin-support.h>
 #include <string>
 #include <memory>

--- a/src/online_status.hpp
+++ b/src/online_status.hpp
@@ -5,16 +5,23 @@
 #include <obs-frontend-api.h>
 #include <plugin-support.h>
 #include <string>
+#include <memory>
+
+// Smart wrapper for obs_source_t (calls obs_source_release automatically)
+struct SourceReleaser {
+    void operator()(obs_source_t *p) const noexcept { if (p) obs_source_release(p); }
+};
+using SourceHandle = std::unique_ptr<obs_source_t, SourceReleaser>;
 
 // All runtime data is kept in this struct
 struct OnlineStatus {
     // Dropping children
-    obs_source_t *status_text = nullptr;
-    obs_source_t *status_image = nullptr;
+    SourceHandle status_text;
+    SourceHandle status_image;
 
     // Stable-state children
-    obs_source_t *status_text_stable = nullptr;
-    obs_source_t *status_image_stable = nullptr;
+    SourceHandle status_text_stable;
+    SourceHandle status_image_stable;
 
     // Dropping content
     std::string text;

--- a/src/online_status.hpp
+++ b/src/online_status.hpp
@@ -9,58 +9,62 @@
 
 // Smart wrapper for obs_source_t (calls obs_source_release automatically)
 struct SourceReleaser {
-    void operator()(obs_source_t *p) const noexcept { if (p) obs_source_release(p); }
+	void operator()(obs_source_t *p) const noexcept
+	{
+		if (p)
+			obs_source_release(p);
+	}
 };
 using SourceHandle = std::unique_ptr<obs_source_t, SourceReleaser>;
 
 // All runtime data is kept in this struct
 struct OnlineStatus {
-    // Dropping children
-    SourceHandle status_text;
-    SourceHandle status_image;
+	// Dropping children
+	SourceHandle status_text;
+	SourceHandle status_image;
 
-    // Stable-state children
-    SourceHandle status_text_stable;
-    SourceHandle status_image_stable;
+	// Stable-state children
+	SourceHandle status_text_stable;
+	SourceHandle status_image_stable;
 
-    // Dropping content
-    std::string text;
-    std::string image_path;
+	// Dropping content
+	std::string text;
+	std::string image_path;
 
-    // Stable content
-    std::string stable_text_msg;
-    std::string stable_image_path;
+	// Stable content
+	std::string stable_text_msg;
+	std::string stable_image_path;
 
-    // Visibility/state
-    bool visible = false;
-    bool auto_visible = false;
-    int content_mode = 0; // 0 = text, 1 = image
-    double drop_threshold_pct = 1.0; // show when pct dropped in interval >= this
-    float hide_after_sec = 3.0f;     // hide after this many seconds without drops
-    uint64_t prev_total = 0;
-    uint64_t prev_dropped = 0;
-    float since_last_drop = 0.0f;
+	// Visibility/state
+	bool visible = false;
+	bool auto_visible = false;
+	int content_mode = 0;            // 0 = text, 1 = image
+	double drop_threshold_pct = 1.0; // show when pct dropped in interval >= this
+	float hide_after_sec = 3.0f;     // hide after this many seconds without drops
+	uint64_t prev_total = 0;
+	uint64_t prev_dropped = 0;
+	float since_last_drop = 0.0f;
 
-    // Blink config/state (separate for dropping and stable overlays)
-    bool drop_blink_enabled = false;
-    double drop_blink_rate_hz = 1.0; // blinks per second
-    double drop_blink_phase = 0.0;   // seconds into current period
-    bool drop_blink_on = true;       // current half-cycle visible?
+	// Blink config/state (separate for dropping and stable overlays)
+	bool drop_blink_enabled = false;
+	double drop_blink_rate_hz = 1.0; // blinks per second
+	double drop_blink_phase = 0.0;   // seconds into current period
+	bool drop_blink_on = true;       // current half-cycle visible?
 
-    bool stable_blink_enabled = false;
-    double stable_blink_rate_hz = 1.0;
-    double stable_blink_phase = 0.0;
-    bool stable_blink_on = true;
+	bool stable_blink_enabled = false;
+	double stable_blink_rate_hz = 1.0;
+	double stable_blink_phase = 0.0;
+	bool stable_blink_on = true;
 
-    // Stable overlay options/state
-    bool  stable_enabled = true;
-    int   stable_mode = 0;            // 0=text, 1=image
-    float stable_duration_sec = 3.0f; // how long to show after recovery
-    float stable_timer = 0.0f;
-    bool  stable_visible = false;
+	// Stable overlay options/state
+	bool stable_enabled = true;
+	int stable_mode = 0;              // 0=text, 1=image
+	float stable_duration_sec = 3.0f; // how long to show after recovery
+	float stable_timer = 0.0f;
+	bool stable_visible = false;
 
-    // Testing helpers
-    bool  test_force_drop = false;
+	// Testing helpers
+	bool test_force_drop = false;
 };
 
 // OBS source callbacks

--- a/src/online_status.hpp
+++ b/src/online_status.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <obs-module.h>
+#include <obs-frontend-api.h>
+#include <plugin-support.h>
+#include <string>
+
+struct OnlineStatus {
+    // Dropping children
+    obs_source_t *status_text = nullptr;
+    obs_source_t *status_image = nullptr;
+
+    // Stable-state children
+    obs_source_t *status_text_stable = nullptr;
+    obs_source_t *status_image_stable = nullptr;
+
+    // Dropping content
+    std::string text;
+    std::string image_path;
+
+    // Stable content
+    std::string stable_text_msg;
+    std::string stable_image_path;
+
+    // Visibility/state
+    bool visible = false;
+    bool auto_visible = false;
+    int content_mode = 0; // 0 = text, 1 = image
+    double drop_threshold_pct = 1.0; // show when pct dropped in interval >= this
+    float hide_after_sec = 3.0f;     // hide after this many seconds without drops
+    uint64_t prev_total = 0;
+    uint64_t prev_dropped = 0;
+    float since_last_drop = 0.0f;
+
+    // Blink config/state (separate for dropping and stable overlays)
+    bool drop_blink_enabled = false;
+    double drop_blink_rate_hz = 1.0; // blinks per second
+    double drop_blink_phase = 0.0;   // seconds into current period
+    bool drop_blink_on = true;       // current half-cycle visible?
+
+    bool stable_blink_enabled = false;
+    double stable_blink_rate_hz = 1.0;
+    double stable_blink_phase = 0.0;
+    bool stable_blink_on = true;
+
+    // Stable overlay options/state
+    bool  stable_enabled = true;
+    int   stable_mode = 0;            // 0=text, 1=image
+    float stable_duration_sec = 3.0f; // how long to show after recovery
+    float stable_timer = 0.0f;
+    bool  stable_visible = false;
+
+    // Testing helpers
+    bool  test_force_drop = false;
+};
+
+// OBS source callbacks
+const char *online_status_get_name(void *);
+void *online_status_create(obs_data_t *settings, obs_source_t *owner);
+void online_status_destroy(void *data);
+uint32_t online_status_get_width(void *data);
+uint32_t online_status_get_height(void *data);
+void online_status_defaults(obs_data_t *settings);
+obs_properties_t *online_status_properties(void *data);
+void online_status_update(void *data, obs_data_t *settings);
+void online_status_video_tick(void *data, float seconds);
+void online_status_video_render(void *data, gs_effect_t *effect);
+
+// Registration
+void register_online_status_source(void);

--- a/src/online_status.hpp
+++ b/src/online_status.hpp
@@ -6,6 +6,7 @@
 #include <plugin-support.h>
 #include <string>
 
+// All runtime data is kept in this struct
 struct OnlineStatus {
     // Dropping children
     obs_source_t *status_text = nullptr;

--- a/src/online_status_properties.cpp
+++ b/src/online_status_properties.cpp
@@ -2,195 +2,203 @@
 #include "online_status.hpp"
 
 // Property UI visibility refresher (C-callable for OBS callbacks)
-static bool online_status_properties_refresh(obs_properties_t *props, obs_property_t * /*property*/, obs_data_t *settings)
+static bool online_status_properties_refresh(obs_properties_t *props, obs_property_t * /*property*/,
+					     obs_data_t *settings)
 {
-    auto set_vis = [&](const char *name, bool v) {
-        if (obs_property_t *pp = obs_properties_get(props, name))
-            obs_property_set_visible(pp, v);
-    };
+	auto set_vis = [&](const char *name, bool v) {
+		if (obs_property_t *pp = obs_properties_get(props, name))
+			obs_property_set_visible(pp, v);
+	};
 
-    int section = (int)obs_data_get_int(settings, "ui_section");
-    int mode_val = (int)obs_data_get_int(settings, "content_mode");
+	int section = (int)obs_data_get_int(settings, "ui_section");
+	int mode_val = (int)obs_data_get_int(settings, "content_mode");
 
-    // Dropping group inner properties
-    if (obs_property_t *grp = obs_properties_get(props, "dropping_group")) {
-        obs_properties_t *inner = obs_property_group_content(grp);
-        if (inner) {
-            bool show_drop = (section == 0);
-            if (obs_property_t *pp = obs_properties_get(inner, "content_mode"))
-                obs_property_set_visible(pp, show_drop);
-            if (obs_property_t *pp = obs_properties_get(inner, "status_text"))
-                obs_property_set_visible(pp, show_drop && mode_val == 0);
-            if (obs_property_t *pp = obs_properties_get(inner, "image_path"))
-                obs_property_set_visible(pp, show_drop && mode_val == 1);
-            if (obs_property_t *pp = obs_properties_get(inner, "drop_threshold_pct"))
-                obs_property_set_visible(pp, show_drop);
-            if (obs_property_t *pp = obs_properties_get(inner, "hide_after_sec"))
-                obs_property_set_visible(pp, show_drop);
-            if (obs_property_t *pp = obs_properties_get(inner, "drop_blink_enabled"))
-                obs_property_set_visible(pp, show_drop);
-            if (obs_property_t *pp = obs_properties_get(inner, "drop_blink_rate_hz"))
-                obs_property_set_visible(pp, show_drop);
-        }
-    }
+	// Dropping group inner properties
+	if (obs_property_t *grp = obs_properties_get(props, "dropping_group")) {
+		obs_properties_t *inner = obs_property_group_content(grp);
+		if (inner) {
+			bool show_drop = (section == 0);
+			if (obs_property_t *pp = obs_properties_get(inner, "content_mode"))
+				obs_property_set_visible(pp, show_drop);
+			if (obs_property_t *pp = obs_properties_get(inner, "status_text"))
+				obs_property_set_visible(pp, show_drop && mode_val == 0);
+			if (obs_property_t *pp = obs_properties_get(inner, "image_path"))
+				obs_property_set_visible(pp, show_drop && mode_val == 1);
+			if (obs_property_t *pp = obs_properties_get(inner, "drop_threshold_pct"))
+				obs_property_set_visible(pp, show_drop);
+			if (obs_property_t *pp = obs_properties_get(inner, "hide_after_sec"))
+				obs_property_set_visible(pp, show_drop);
+			if (obs_property_t *pp = obs_properties_get(inner, "drop_blink_enabled"))
+				obs_property_set_visible(pp, show_drop);
+			if (obs_property_t *pp = obs_properties_get(inner, "drop_blink_rate_hz"))
+				obs_property_set_visible(pp, show_drop);
+		}
+	}
 
-    // Stable group inner properties
-    if (obs_property_t *grp = obs_properties_get(props, "stable_group")) {
-        obs_properties_t *inner = obs_property_group_content(grp);
-        if (inner) {
-            bool s_enabled_v = obs_data_get_bool(settings, "stable_enabled");
-            int s_mode = (int)obs_data_get_int(settings, "stable_mode");
-            bool show_inner = (section == 1) && s_enabled_v;
+	// Stable group inner properties
+	if (obs_property_t *grp = obs_properties_get(props, "stable_group")) {
+		obs_properties_t *inner = obs_property_group_content(grp);
+		if (inner) {
+			bool s_enabled_v = obs_data_get_bool(settings, "stable_enabled");
+			int s_mode = (int)obs_data_get_int(settings, "stable_mode");
+			bool show_inner = (section == 1) && s_enabled_v;
 
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_mode"))
-                obs_property_set_visible(pp, section == 1);
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_text"))
-                obs_property_set_visible(pp, show_inner && s_mode == 0);
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_image_path"))
-                obs_property_set_visible(pp, show_inner && s_mode == 1);
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_enabled"))
-                obs_property_set_visible(pp, section == 1);
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_duration_sec"))
-                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_blink_enabled"))
-                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_blink_rate_hz"))
-                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
-        }
-    }
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_mode"))
+				obs_property_set_visible(pp, section == 1);
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_text"))
+				obs_property_set_visible(pp, show_inner && s_mode == 0);
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_image_path"))
+				obs_property_set_visible(pp, show_inner && s_mode == 1);
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_enabled"))
+				obs_property_set_visible(pp, section == 1);
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_duration_sec"))
+				obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_blink_enabled"))
+				obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_blink_rate_hz"))
+				obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+		}
+	}
 
-    // Pseudo-tabs visibility (no separate Blink tab)
-    bool show_dropping = (section == 0);
-    bool show_stable   = (section == 1);
-    bool show_adv      = (section == 2);
+	// Pseudo-tabs visibility (no separate Blink tab)
+	bool show_dropping = (section == 0);
+	bool show_stable = (section == 1);
+	bool show_adv = (section == 2);
 
-    auto show_adv_field = [&](const char *name) { set_vis(name, show_adv); };
-    show_adv_field("visible");
-    show_adv_field("test_force_drop");
-    show_adv_field("test_simulate_spike");
-    show_adv_field("test_show_stable");
-    show_adv_field("test_hide_all");
+	auto show_adv_field = [&](const char *name) {
+		set_vis(name, show_adv);
+	};
+	show_adv_field("visible");
+	show_adv_field("test_force_drop");
+	show_adv_field("test_simulate_spike");
+	show_adv_field("test_show_stable");
+	show_adv_field("test_hide_all");
 
-    if (obs_property_t *grp = obs_properties_get(props, "dropping_group"))
-        obs_property_set_visible(grp, show_dropping);
-    if (obs_property_t *grp = obs_properties_get(props, "stable_group"))
-        obs_property_set_visible(grp, show_stable);
-    return true;
+	if (obs_property_t *grp = obs_properties_get(props, "dropping_group"))
+		obs_property_set_visible(grp, show_dropping);
+	if (obs_property_t *grp = obs_properties_get(props, "stable_group"))
+		obs_property_set_visible(grp, show_stable);
+	return true;
 }
 
 // Advanced testing buttons
 static bool online_status_btn_simulate_spike(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
 {
-    auto *s = static_cast<OnlineStatus *>(data);
-    if (!s) return false;
-    s->auto_visible = true;
-    s->since_last_drop = 0.0f;
-    s->stable_visible = false;
-    s->stable_timer = 0.0f;
-    return true; // refresh UI
+	auto *s = static_cast<OnlineStatus *>(data);
+	if (!s)
+		return false;
+	s->auto_visible = true;
+	s->since_last_drop = 0.0f;
+	s->stable_visible = false;
+	s->stable_timer = 0.0f;
+	return true; // refresh UI
 }
 
 static bool online_status_btn_show_stable(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
 {
-    auto *s = static_cast<OnlineStatus *>(data);
-    if (!s) return false;
-    s->auto_visible = false;
-    s->stable_visible = true;
-    s->stable_timer = s->stable_duration_sec;
-    return true;
+	auto *s = static_cast<OnlineStatus *>(data);
+	if (!s)
+		return false;
+	s->auto_visible = false;
+	s->stable_visible = true;
+	s->stable_timer = s->stable_duration_sec;
+	return true;
 }
 
 static bool online_status_btn_hide_all(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
 {
-    auto *s = static_cast<OnlineStatus *>(data);
-    if (!s) return false;
-    s->auto_visible = false;
-    s->stable_visible = false;
-    s->stable_timer = 0.0f;
-    return true;
+	auto *s = static_cast<OnlineStatus *>(data);
+	if (!s)
+		return false;
+	s->auto_visible = false;
+	s->stable_visible = false;
+	s->stable_timer = 0.0f;
+	return true;
 }
 
 obs_properties_t *online_status_properties(void *data)
 {
-    UNUSED_PARAMETER(data);
-    obs_properties_t *props = obs_properties_create();
+	UNUSED_PARAMETER(data);
+	obs_properties_t *props = obs_properties_create();
 
-    // Section selector to simulate tabs
-    obs_property_t *section = obs_properties_add_list(
-        props, "ui_section", "Section",
-        OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-    obs_property_list_add_int(section, "Dropping", 0);
-    obs_property_list_add_int(section, "Stable", 1);
-    obs_property_list_add_int(section, "Advanced", 2);
+	// Section selector to simulate tabs
+	obs_property_t *section =
+		obs_properties_add_list(props, "ui_section", "Section", OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(section, "Dropping", 0);
+	obs_property_list_add_int(section, "Stable", 1);
+	obs_property_list_add_int(section, "Advanced", 2);
 
-    // Dropping overlay group
-    obs_properties_t *dropping = obs_properties_create();
-    obs_property_t *mode = obs_properties_add_list(dropping, "content_mode", "Content Type (when dropping)",
-                                                   OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-    obs_property_list_add_int(mode, "Text", 0);
-    obs_property_list_add_int(mode, "Image", 1);
+	// Dropping overlay group
+	obs_properties_t *dropping = obs_properties_create();
+	obs_property_t *mode = obs_properties_add_list(dropping, "content_mode", "Content Type (when dropping)",
+						       OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(mode, "Text", 0);
+	obs_property_list_add_int(mode, "Image", 1);
 
-    obs_properties_add_text(dropping, "status_text", "Text to show while dropping", OBS_TEXT_DEFAULT);
-    obs_properties_add_path(dropping, "image_path", "Image file (while dropping)", OBS_PATH_FILE,
-                            "Image files (*.png *.jpg *.jpeg *.bmp *.gif);;All files (*.*)", nullptr);
+	obs_properties_add_text(dropping, "status_text", "Text to show while dropping", OBS_TEXT_DEFAULT);
+	obs_properties_add_path(dropping, "image_path", "Image file (while dropping)", OBS_PATH_FILE,
+				"Image files (*.png *.jpg *.jpeg *.bmp *.gif);;All files (*.*)", nullptr);
 
-    obs_properties_add_float_slider(dropping, "drop_threshold_pct", "Drop % threshold (per-interval)", 0.0, 100.0,
-        0.1);
-    obs_properties_add_float_slider(dropping, "hide_after_sec", "Hide after seconds without drops", 0.0, 30.0, 0.1);
-    // Blink controls (Dropping)
-    obs_properties_add_bool(dropping, "drop_blink_enabled", "Blink (while dropping)");
-    obs_properties_add_float_slider(dropping, "drop_blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
+	obs_properties_add_float_slider(dropping, "drop_threshold_pct", "Drop % threshold (per-interval)", 0.0, 100.0,
+					0.1);
+	obs_properties_add_float_slider(dropping, "hide_after_sec", "Hide after seconds without drops", 0.0, 30.0, 0.1);
+	// Blink controls (Dropping)
+	obs_properties_add_bool(dropping, "drop_blink_enabled", "Blink (while dropping)");
+	obs_properties_add_float_slider(dropping, "drop_blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
 
-    obs_property_t *dropping_group = obs_properties_add_group(props, "dropping_group", "When dropping frames",
-                                                             OBS_GROUP_NORMAL, dropping);
-    obs_properties_add_bool(props, "visible", "Test text that auto-shows when dropping frames(for debugging)");
+	obs_property_t *dropping_group =
+		obs_properties_add_group(props, "dropping_group", "When dropping frames", OBS_GROUP_NORMAL, dropping);
+	obs_properties_add_bool(props, "visible", "Test text that auto-shows when dropping frames(for debugging)");
 
-    // Stable overlay group
-    obs_properties_t *stable = obs_properties_create();
-    obs_properties_add_bool(stable, "stable_enabled", "Show message when connection is stable");
-    obs_property_t *smode = obs_properties_add_list(stable, "stable_mode", "Content Type (when stable)",
-                                                    OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-    obs_property_list_add_int(smode, "Text", 0);
-    obs_property_list_add_int(smode, "Image", 1);
-    obs_properties_add_text(stable, "stable_text", "Stable text", OBS_TEXT_DEFAULT);
-    obs_properties_add_path(stable, "stable_image_path", "Stable image file", OBS_PATH_FILE,
-                            "Image files (*.png *.jpg *.jpeg *.bmp *.gif);;All files (*.*)", nullptr);
-    obs_properties_add_float_slider(stable, "stable_duration_sec", "Stable message duration (seconds)",
-                                    0.0, 60.0, 0.1);
-    // Blink controls (Stable)
-    obs_properties_add_bool(stable, "stable_blink_enabled", "Blink (stable message)");
-    obs_properties_add_float_slider(stable, "stable_blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
+	// Stable overlay group
+	obs_properties_t *stable = obs_properties_create();
+	obs_properties_add_bool(stable, "stable_enabled", "Show message when connection is stable");
+	obs_property_t *smode = obs_properties_add_list(stable, "stable_mode", "Content Type (when stable)",
+							OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(smode, "Text", 0);
+	obs_property_list_add_int(smode, "Image", 1);
+	obs_properties_add_text(stable, "stable_text", "Stable text", OBS_TEXT_DEFAULT);
+	obs_properties_add_path(stable, "stable_image_path", "Stable image file", OBS_PATH_FILE,
+				"Image files (*.png *.jpg *.jpeg *.bmp *.gif);;All files (*.*)", nullptr);
+	obs_properties_add_float_slider(stable, "stable_duration_sec", "Stable message duration (seconds)", 0.0, 60.0,
+					0.1);
+	// Blink controls (Stable)
+	obs_properties_add_bool(stable, "stable_blink_enabled", "Blink (stable message)");
+	obs_properties_add_float_slider(stable, "stable_blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
 
-    obs_property_t *stable_group = obs_properties_add_group(props, "stable_group", "When connection stabilizes", OBS_GROUP_NORMAL, stable);
+	obs_property_t *stable_group =
+		obs_properties_add_group(props, "stable_group", "When connection stabilizes", OBS_GROUP_NORMAL, stable);
 
-    // Advanced: testing controls
-    obs_properties_add_bool(props, "test_force_drop", "Test: Force dropping overlay");
-    obs_properties_add_button(props, "test_simulate_spike", "Test: Simulate drop spike", online_status_btn_simulate_spike);
-    obs_properties_add_button(props, "test_show_stable", "Test: Show stable message now", online_status_btn_show_stable);
-    obs_properties_add_button(props, "test_hide_all", "Test: Hide overlays", online_status_btn_hide_all);
+	// Advanced: testing controls
+	obs_properties_add_bool(props, "test_force_drop", "Test: Force dropping overlay");
+	obs_properties_add_button(props, "test_simulate_spike", "Test: Simulate drop spike",
+				  online_status_btn_simulate_spike);
+	obs_properties_add_button(props, "test_show_stable", "Test: Show stable message now",
+				  online_status_btn_show_stable);
+	obs_properties_add_button(props, "test_hide_all", "Test: Hide overlays", online_status_btn_hide_all);
 
-    // Dynamic visibility handled by C-callback online_status_properties_refresh()
+	// Dynamic visibility handled by C-callback online_status_properties_refresh()
 
-    // Hook callbacks
-    obs_property_set_modified_callback(section, online_status_properties_refresh);
-    obs_property_set_modified_callback(mode,    online_status_properties_refresh);
-    // Hook inner dropping toggles
-    if (obs_property_t *grp = dropping_group) {
-        obs_properties_t *inner = obs_property_group_content(grp);
-        if (inner) {
-            if (obs_property_t *pp = obs_properties_get(inner, "content_mode"))
-                obs_property_set_modified_callback(pp, online_status_properties_refresh);
-        }
-    }
-    // Also attach to stable group inner toggles
-    if (obs_property_t *grp = stable_group) {
-        obs_properties_t *inner = obs_property_group_content(grp);
-        if (inner) {
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_enabled"))
-                obs_property_set_modified_callback(pp, online_status_properties_refresh);
-            if (obs_property_t *pp = obs_properties_get(inner, "stable_mode"))
-                obs_property_set_modified_callback(pp, online_status_properties_refresh);
-        }
-    }
-    return props;
+	// Hook callbacks
+	obs_property_set_modified_callback(section, online_status_properties_refresh);
+	obs_property_set_modified_callback(mode, online_status_properties_refresh);
+	// Hook inner dropping toggles
+	if (obs_property_t *grp = dropping_group) {
+		obs_properties_t *inner = obs_property_group_content(grp);
+		if (inner) {
+			if (obs_property_t *pp = obs_properties_get(inner, "content_mode"))
+				obs_property_set_modified_callback(pp, online_status_properties_refresh);
+		}
+	}
+	// Also attach to stable group inner toggles
+	if (obs_property_t *grp = stable_group) {
+		obs_properties_t *inner = obs_property_group_content(grp);
+		if (inner) {
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_enabled"))
+				obs_property_set_modified_callback(pp, online_status_properties_refresh);
+			if (obs_property_t *pp = obs_properties_get(inner, "stable_mode"))
+				obs_property_set_modified_callback(pp, online_status_properties_refresh);
+		}
+	}
+	return props;
 }

--- a/src/online_status_properties.cpp
+++ b/src/online_status_properties.cpp
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "online_status.hpp"
+
+// Property UI visibility refresher (C-callable for OBS callbacks)
+static bool online_status_properties_refresh(obs_properties_t *props, obs_property_t * /*property*/, obs_data_t *settings)
+{
+    auto set_vis = [&](const char *name, bool v) {
+        if (obs_property_t *pp = obs_properties_get(props, name))
+            obs_property_set_visible(pp, v);
+    };
+
+    int section = (int)obs_data_get_int(settings, "ui_section");
+    int mode_val = (int)obs_data_get_int(settings, "content_mode");
+
+    // Dropping group inner properties
+    if (obs_property_t *grp = obs_properties_get(props, "dropping_group")) {
+        obs_properties_t *inner = obs_property_group_content(grp);
+        if (inner) {
+            bool show_drop = (section == 0);
+            if (obs_property_t *pp = obs_properties_get(inner, "content_mode"))
+                obs_property_set_visible(pp, show_drop);
+            if (obs_property_t *pp = obs_properties_get(inner, "status_text"))
+                obs_property_set_visible(pp, show_drop && mode_val == 0);
+            if (obs_property_t *pp = obs_properties_get(inner, "image_path"))
+                obs_property_set_visible(pp, show_drop && mode_val == 1);
+            if (obs_property_t *pp = obs_properties_get(inner, "drop_threshold_pct"))
+                obs_property_set_visible(pp, show_drop);
+            if (obs_property_t *pp = obs_properties_get(inner, "hide_after_sec"))
+                obs_property_set_visible(pp, show_drop);
+            if (obs_property_t *pp = obs_properties_get(inner, "drop_blink_enabled"))
+                obs_property_set_visible(pp, show_drop);
+            if (obs_property_t *pp = obs_properties_get(inner, "drop_blink_rate_hz"))
+                obs_property_set_visible(pp, show_drop);
+        }
+    }
+
+    // Stable group inner properties
+    if (obs_property_t *grp = obs_properties_get(props, "stable_group")) {
+        obs_properties_t *inner = obs_property_group_content(grp);
+        if (inner) {
+            bool s_enabled_v = obs_data_get_bool(settings, "stable_enabled");
+            int s_mode = (int)obs_data_get_int(settings, "stable_mode");
+            bool show_inner = (section == 1) && s_enabled_v;
+
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_mode"))
+                obs_property_set_visible(pp, section == 1);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_text"))
+                obs_property_set_visible(pp, show_inner && s_mode == 0);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_image_path"))
+                obs_property_set_visible(pp, show_inner && s_mode == 1);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_enabled"))
+                obs_property_set_visible(pp, section == 1);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_duration_sec"))
+                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_blink_enabled"))
+                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_blink_rate_hz"))
+                obs_property_set_visible(pp, (section == 1) && s_enabled_v);
+        }
+    }
+
+    // Pseudo-tabs visibility (no separate Blink tab)
+    bool show_dropping = (section == 0);
+    bool show_stable   = (section == 1);
+    bool show_adv      = (section == 2);
+
+    auto show_adv_field = [&](const char *name) { set_vis(name, show_adv); };
+    show_adv_field("visible");
+    show_adv_field("test_force_drop");
+    show_adv_field("test_simulate_spike");
+    show_adv_field("test_show_stable");
+    show_adv_field("test_hide_all");
+
+    if (obs_property_t *grp = obs_properties_get(props, "dropping_group"))
+        obs_property_set_visible(grp, show_dropping);
+    if (obs_property_t *grp = obs_properties_get(props, "stable_group"))
+        obs_property_set_visible(grp, show_stable);
+    return true;
+}
+
+// Advanced testing buttons
+static bool online_status_btn_simulate_spike(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
+{
+    auto *s = static_cast<OnlineStatus *>(data);
+    if (!s) return false;
+    s->auto_visible = true;
+    s->since_last_drop = 0.0f;
+    s->stable_visible = false;
+    s->stable_timer = 0.0f;
+    return true; // refresh UI
+}
+
+static bool online_status_btn_show_stable(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
+{
+    auto *s = static_cast<OnlineStatus *>(data);
+    if (!s) return false;
+    s->auto_visible = false;
+    s->stable_visible = true;
+    s->stable_timer = s->stable_duration_sec;
+    return true;
+}
+
+static bool online_status_btn_hide_all(obs_properties_t * /*props*/, obs_property_t * /*p*/, void *data)
+{
+    auto *s = static_cast<OnlineStatus *>(data);
+    if (!s) return false;
+    s->auto_visible = false;
+    s->stable_visible = false;
+    s->stable_timer = 0.0f;
+    return true;
+}
+
+obs_properties_t *online_status_properties(void *data)
+{
+    UNUSED_PARAMETER(data);
+    obs_properties_t *props = obs_properties_create();
+
+    // Section selector to simulate tabs
+    obs_property_t *section = obs_properties_add_list(
+        props, "ui_section", "Section",
+        OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+    obs_property_list_add_int(section, "Dropping", 0);
+    obs_property_list_add_int(section, "Stable", 1);
+    obs_property_list_add_int(section, "Advanced", 2);
+
+    // Dropping overlay group
+    obs_properties_t *dropping = obs_properties_create();
+    obs_property_t *mode = obs_properties_add_list(dropping, "content_mode", "Content Type (when dropping)",
+                                                   OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+    obs_property_list_add_int(mode, "Text", 0);
+    obs_property_list_add_int(mode, "Image", 1);
+
+    obs_properties_add_text(dropping, "status_text", "Text to show while dropping", OBS_TEXT_DEFAULT);
+    obs_properties_add_path(dropping, "image_path", "Image file (while dropping)", OBS_PATH_FILE,
+                            "Image files (*.png *.jpg *.jpeg *.bmp *.gif);;All files (*.*)", nullptr);
+
+    obs_properties_add_float_slider(dropping, "drop_threshold_pct", "Drop % threshold (per-interval)", 0.0, 100.0,
+        0.1);
+    obs_properties_add_float_slider(dropping, "hide_after_sec", "Hide after seconds without drops", 0.0, 30.0, 0.1);
+    // Blink controls (Dropping)
+    obs_properties_add_bool(dropping, "drop_blink_enabled", "Blink (while dropping)");
+    obs_properties_add_float_slider(dropping, "drop_blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
+
+    obs_property_t *dropping_group = obs_properties_add_group(props, "dropping_group", "When dropping frames",
+                                                             OBS_GROUP_NORMAL, dropping);
+    obs_properties_add_bool(props, "visible", "Test text that auto-shows when dropping frames(for debugging)");
+
+    // Stable overlay group
+    obs_properties_t *stable = obs_properties_create();
+    obs_properties_add_bool(stable, "stable_enabled", "Show message when connection is stable");
+    obs_property_t *smode = obs_properties_add_list(stable, "stable_mode", "Content Type (when stable)",
+                                                    OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+    obs_property_list_add_int(smode, "Text", 0);
+    obs_property_list_add_int(smode, "Image", 1);
+    obs_properties_add_text(stable, "stable_text", "Stable text", OBS_TEXT_DEFAULT);
+    obs_properties_add_path(stable, "stable_image_path", "Stable image file", OBS_PATH_FILE,
+                            "Image files (*.png *.jpg *.jpeg *.bmp *.gif);;All files (*.*)", nullptr);
+    obs_properties_add_float_slider(stable, "stable_duration_sec", "Stable message duration (seconds)",
+                                    0.0, 60.0, 0.1);
+    // Blink controls (Stable)
+    obs_properties_add_bool(stable, "stable_blink_enabled", "Blink (stable message)");
+    obs_properties_add_float_slider(stable, "stable_blink_rate_hz", "Blink rate (Hz)", 0.0, 10.0, 0.1);
+
+    obs_property_t *stable_group = obs_properties_add_group(props, "stable_group", "When connection stabilizes", OBS_GROUP_NORMAL, stable);
+
+    // Advanced: testing controls
+    obs_properties_add_bool(props, "test_force_drop", "Test: Force dropping overlay");
+    obs_properties_add_button(props, "test_simulate_spike", "Test: Simulate drop spike", online_status_btn_simulate_spike);
+    obs_properties_add_button(props, "test_show_stable", "Test: Show stable message now", online_status_btn_show_stable);
+    obs_properties_add_button(props, "test_hide_all", "Test: Hide overlays", online_status_btn_hide_all);
+
+    // Dynamic visibility handled by C-callback online_status_properties_refresh()
+
+    // Hook callbacks
+    obs_property_set_modified_callback(section, online_status_properties_refresh);
+    obs_property_set_modified_callback(mode,    online_status_properties_refresh);
+    // Hook inner dropping toggles
+    if (obs_property_t *grp = dropping_group) {
+        obs_properties_t *inner = obs_property_group_content(grp);
+        if (inner) {
+            if (obs_property_t *pp = obs_properties_get(inner, "content_mode"))
+                obs_property_set_modified_callback(pp, online_status_properties_refresh);
+        }
+    }
+    // Also attach to stable group inner toggles
+    if (obs_property_t *grp = stable_group) {
+        obs_properties_t *inner = obs_property_group_content(grp);
+        if (inner) {
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_enabled"))
+                obs_property_set_modified_callback(pp, online_status_properties_refresh);
+            if (obs_property_t *pp = obs_properties_get(inner, "stable_mode"))
+                obs_property_set_modified_callback(pp, online_status_properties_refresh);
+        }
+    }
+    return props;
+}


### PR DESCRIPTION
This pull request adds a new source properties implementation for the online status plugin, enabling a more advanced and user-friendly configuration UI in OBS. It introduces a new source file for handling properties, updates the build to include it, and adds documentation to explain the new configuration sections.

**UI/UX Improvements for Plugin Configuration:**

* Added a new `online_status_properties.cpp` file that implements dynamic and context-sensitive property controls for the plugin, including section "tabs," advanced test buttons, and conditional visibility for options.
* Updated the CMake build system to include the new `src/online_status_properties.cpp` source file.
* Expanded the README with a new "Sections Explained" guide, describing the Dropping, Stable, and Advanced configuration sections for users.

**Codebase Structure and API:**

* Introduced a new header, `online_status.hpp`, which defines the `OnlineStatus` struct (holding all runtime data and state), smart pointer wrappers for OBS sources, and declares all plugin callbacks and registration functions.